### PR TITLE
Allow usage on stable rust via --no-default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ repository = "https://github.com/nikomatsakis/ena"
 version = "0.3.0"
 authors = ["Niko Matsakis <niko@alum.mit.edu>"]
 
+[features]
+default = ["unstable"]
+unstable = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,10 +8,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(all(feature = "unstable", test), feature(test))]
 #![allow(dead_code)]
-#![feature(conservative_impl_trait)]
-#![feature(static_in_const)]
+#![cfg_attr(feature = "unstable", feature(conservative_impl_trait))]
+#![cfg_attr(feature = "unstable", feature(static_in_const))]
 
 #[macro_use]
 mod debug;
@@ -19,6 +19,7 @@ mod debug;
 pub mod constraint;
 pub mod graph;
 pub mod snapshot_vec;
+#[cfg(feature = "unstable")]
 pub mod cc;
 pub mod unify;
 pub mod bitvec;

--- a/src/unify/tests.rs
+++ b/src/unify/tests.rs
@@ -8,7 +8,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(feature = "unstable")]
 extern crate test;
+#[cfg(feature = "unstable")]
 use self::test::Bencher;
 use std::collections::HashSet;
 use std::cmp;
@@ -61,6 +63,7 @@ fn big_array() {
     }
 }
 
+#[cfg(feature = "unstable")]
 #[bench]
 fn big_array_bench(b: &mut Bencher) {
     let mut ut: UnificationTable<UnitKey> = UnificationTable::new();


### PR DESCRIPTION
I'd like to be able to use the unification stuff on stable, although I don't know how you feel about loosing the `cc` module. I didn't try going in and converting it.